### PR TITLE
FIX: declare zdotc as double complex

### DIFF
--- a/complex16/dblasext.F
+++ b/complex16/dblasext.F
@@ -511,7 +511,7 @@ c$OMP& schedule(static)
       end
 
 #ifdef SCIPY_USE_G77_CDOTC_WRAP
-      complex function zdotc(n, cx, incx, cy, incy)
+      double complex function zdotc(n, cx, incx, cy, incy)
       double complex cx(*), cy(*), c
       integer n, incx, incy
       call WZDOTC(n, cx, incx, cy, incy)


### PR DESCRIPTION
- could be source of segfaults in https://github.com/scipy/scipy/issues/15108

Relevant backtrace:
```gdb
Thread 1 received signal SIGSEGV, Segmentation fault.
0x0000000070ffbc87 in acc_zdotc_sub_ () from C:\Users\nmckibben\anaconda3\envs\test_env\lib\site-packages\scipy\.libs\lib_zpropac.3GBPV7TQ5IT2WWYEZDL27566SJHDZCUV.gfortran-win_amd64.dll
(gdb) bt
#0  0x0000000070ffbc87 in acc_zdotc_sub_ () from C:\Users\nmckibben\anaconda3\envs\test_env\lib\site-packages\scipy\.libs\lib_zpropac.3GBPV7TQ5IT2WWYEZDL27566SJHDZCUV.gfortran-win_amd64.dll
#1  0x0000000070fda65f in wzdotc (n=<optimized out>, cx=..., incx=<optimized out>, cy=..., incy=<error reading variable: Cannot access memory at address 0x0>)
    at C:\bld\scipy_1641278188767\work\scipy\_build_utils\src\wrap_g77_abi_f.f:24
#2  0x0000000070fc3773 in zdotc (n=-5, cx=..., incx=<optimized out>, cy=..., incy=1878922240) at C:\bld\scipy_1641278188767\work\scipy\sparse\linalg\_propack\PROPACK\complex16\dblasext.F:517
#3  0x0000000070fc72e6 in pzdotc (n=3, x=..., incx=1, y=..., incy=1) at C:\bld\scipy_1641278188767\work\scipy\sparse\linalg\_propack\PROPACK\complex16\zblasext.F:326
#4  0x0000000070fd2292 in zlanbpro (m=4, n=3, k0=<optimized out>, k=4, aprod=0x7ffb4ab21c50, u=..., ldu=4, v=..., ldv=3, b=..., ldb=4, rnorm=5.4649783593334584, doption=..., ioption=..., dwork=..., zwork=..., iwork=..., zparm=...,
    iparm=..., ierr=0) at C:\bld\scipy_1641278188767\work\scipy\sparse\linalg\_propack\PROPACK\complex16\zlanbpro.F:330
#5  0x0000000000000000 in ?? ()
Backtrace stopped: previous frame inner to this frame (corrupt stack?)
```

Notice that `pzdotc (n=3, x=..., incx=1, y=..., incy=1)` is correct but the call is forwarded to `zdotc (n=-5, cx=..., incx=<optimized out>, cy=..., incy=1878922240)` which contains an `incy` value probably causing the pointer to jump into oblivion corrupting the stack.  `n=-5` is also suspicious and leads me to believe it's a shifting error caused by Fortran's return parameter being declared as the wrong type (`complex` instead of `double complex`)

@h-vetinari you can either update to point at this commit or we can complete this PR as is (won't impact anyone else) and simply rerun the conda-forge CI as is.  While this is a good fix, I suspect we won't know if this is the "actual fix" to Windows segfaults in https://github.com/scipy/scipy/issues/15108 until we run the CI.  If this is the fix, I'd be curious to know why we don't see these segfaults when built in the scipy Windows CI without conda