### PR TITLE
MAINT: Add zzdotc.f from ARPACK F77 code

### DIFF
--- a/complex16/zzdotc.f
+++ b/complex16/zzdotc.f
@@ -1,0 +1,36 @@
+      double complex function zzdotc(n,zx,incx,zy,incy)
+c
+c     forms the dot product of a vector.
+c     jack dongarra, 3/11/78.
+c     modified 12/3/93, array(1) declarations changed to array(*)
+c
+      double complex zx(*),zy(*),ztemp
+      integer i,incx,incy,ix,iy,n
+      ztemp = (0.0d0,0.0d0)
+      zzdotc = (0.0d0,0.0d0)
+      if(n.le.0)return
+      if(incx.eq.1.and.incy.eq.1)go to 20
+c
+c        code for unequal increments or equal increments
+c          not equal to 1
+c
+      ix = 1
+      iy = 1
+      if(incx.lt.0)ix = (-n+1)*incx + 1
+      if(incy.lt.0)iy = (-n+1)*incy + 1
+      do 10 i = 1,n
+        ztemp = ztemp + conjg(zx(ix))*zy(iy)
+        ix = ix + incx
+        iy = iy + incy
+   10 continue
+      zzdotc = ztemp
+      return
+c
+c        code for both increments equal to 1
+c
+   20 do 30 i = 1,n
+        ztemp = ztemp + conjg(zx(i))*zy(i)
+   30 continue
+      zzdotc = ztemp
+      return
+      end


### PR DESCRIPTION
This is a preparation for the disappearing code of ARPACK F77 code that PROPACK uses a file from. After this I'll change the meson file on SciPy side.